### PR TITLE
Bump python from 3.12-slim to 3.13-slim in /mcp

### DIFF
--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Bumps python from 3.12-slim to 3.13-slim.

---
updated-dependencies:
- dependency-name: python dependency-type: direct:production ...